### PR TITLE
Added per-service vhost support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,28 @@
-FROM centos:6
+FROM centos:7
 
 # Install Epel YUM repo
-RUN rpm -i "https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm"
+RUN yum -y install epel-release && \
+	yum clean all
 
 # Install HAproxy/Pen TCP/UDP proxies, Mako for config templates
-RUN yum -y install haproxy pen python-mako && yum clean all
+# Note that httpd package fails to install because of
+#  - https://major.io/2014/03/26/docker-trusted-builds-and-fedora-20/
+RUN yum -y install haproxy pen python-mako; \
+	yum clean all
 
 # Run Pen proxy as user "pen"
 RUN groupadd pen && useradd -g pen pen
 ENV PEN_USER pen
 
+# Install Nginx
+RUN rpm -i "http://nginx.org/packages/rhel/7/noarch/RPMS/nginx-release-rhel-7-0.el7.ngx.noarch.rpm"
+RUN yum -y install nginx && \
+	yum clean all
+
 ENV PYTHONPATH /usr/lib/python
 
 COPY haproxy.cfg.tpl /etc/haproxy/haproxy.cfg.tpl
+COPY nginx.tpl /etc/nginx/conf.d/default.conf.tpl
 COPY pen.cfg.tpl /etc/pen/pen.cfg.tpl
 COPY src /usr/lib/python/proxymatic
 COPY proxymatic.sh /

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ is scaled or fails over.
  * **REFRESH_INTERVAL=60** - Polling interval when using non-event capable backends. Defaults to 60 seconds.
  * **EXPOSE_HOST=false** - Expose services running in net=host mode. May cause port collisions when this container is also run in net=host mode. Defaults to false.
  * **HAPROXY=false** - Use HAproxy for TCP services instead of running everything through Pen. Defaults to false.
+ * **VHOST_DOMAIN** - Configure nginx on port 80 with virtual hosts for each service under this domain.
 
 ## Command Line Usage
 
@@ -38,28 +39,12 @@ Options:
   -e, --expose-host     Expose services running in net=host mode. May cause
                         port collisions when this container is also run in
                         net=host mode [default: False]
-  --pen-template=PENTEMPLATE
-                        Template pen proxy config file [default:
-                        /etc/pen/pen.cfg.tpl]
   --pen-servers=PENSERVERS
                         Max number of backend servers for each pen service
                         [default: 32]
   --pen-clients=PENCLIENTS
                         Max number of pen client connections [default: 8192]
-  --pen-user=PENUSER    User to run pen proxy as [default: pen]
   --haproxy             Use HAproxy for TCP services instead of running everything through Pen [default: False]
-  --haproxy-start=HAPROXYSTART
-                        Command to start HAproxy [default: /etc/init.d/haproxy
-                        start]
-  --haproxy-reload=HAPROXYRELOAD
-                        Command to reload HAproxy [default:
-                        /etc/init.d/haproxy reload]
-  --haproxy-config=HAPROXYCONFIG
-                        HAproxy config file to write [default:
-                        /etc/haproxy/haproxy.cfg]
-  --haproxy-template=HAPROXYTEMPLATE
-                        Template HAproxy config file [default:
-                        /etc/haproxy/haproxy.cfg.tpl]
 ```
 
 ## Marathon
@@ -96,6 +81,25 @@ inside the container.
 	"instances": 2
 }
 ```
+
+## Virtual Hosts
+
+The --vhost-domain and $VHOST_DOMAIN parameter can be used to automatically configure an nginx with 
+virtual hosts for each service. This is similar to the [Deis router](http://docs.deis.io/en/latest/understanding_deis/components/#router) component. 
+To use this feature start proxymatic like
+
+```
+docker run -p 80:80 -e VHOST_DOMAIN=app.example.com
+```
+
+And create a wildcard DNS record that points *.app.example.com to the IP of the 
+container host. Each service will automatically get a vhost under the app.example.com 
+setup in nginx. For example
+
+| URL | Marathon Id | $SERVICE_NAME |
+|:----|:------------|:--------------| 
+| http://myservice.app.example.com | myservice | myservice |
+| http://product-system-service.app.example.com | /product/system/service | product-system-service |
 
 ## Deployment
 

--- a/nginx.tpl
+++ b/nginx.tpl
@@ -1,0 +1,65 @@
+# Copied from https://github.com/jwilder/nginx-proxy and https://github.com/deis/deis/blob/master/router/image/templates/nginx.conf
+
+server_names_hash_bucket_size 128;
+
+tcp_nopush on;
+tcp_nodelay on;
+gzip on;
+    
+# If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+# scheme used to connect to this server
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
+# If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
+# Connection header that may have been passed to this server
+map $http_upgrade $proxy_connection {
+  default upgrade;
+  '' close;
+}
+
+gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+log_format vhost '$host $remote_addr - $remote_user [$time_local] '
+                 '"$request" $status $body_bytes_sent '
+                 '"$http_referer" "$http_user_agent"';
+
+access_log /proc/self/fd/1 vhost;
+error_log /proc/self/fd/2;
+
+# HTTP 1.1 support
+proxy_http_version 1.1;
+proxy_buffering off;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $proxy_connection;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+
+server {
+	listen 80;
+	server_name _; # This is just an invalid value which will never trigger on a real hostname.
+	return 503;
+}
+
+% for service in services.values():
+# ${service.name} (${service.source})
+upstream ${service.name}.${domain} {
+% 	for server in service.servers:
+	server ${server.ip}:${server.port};
+% 	endfor  
+}
+
+server {
+	server_name ${service.name}.${domain};
+
+	location / {
+		proxy_pass http://${service.name}.${domain};
+	}
+}
+
+
+% endfor

--- a/src/backend/haproxy.py
+++ b/src/backend/haproxy.py
@@ -3,11 +3,6 @@ from mako.template import Template
 from proxymatic.util import *
 
 class HAProxyBackend(object):
-    def __init__(self, reload, cfgtemplate, target):
-        self._reload = reload
-        self._cfgtemplate = cfgtemplate
-        self._target = target
-        
     def update(self, source, services):
         # HAproxy only supports TCP
         accepted = {}
@@ -16,11 +11,11 @@ class HAProxyBackend(object):
                 accepted[key] = service
         
         # Expand the config template
-        template = Template(filename=self._cfgtemplate)
-        config = template.render(services=accepted, mangle=mangle)
-        with open(self._target, 'w') as f:
+        template = Template(filename='/etc/haproxy/haproxy.cfg.tpl')
+        config = template.render(services=accepted)
+        with open('/etc/haproxy/haproxy.cfg', 'w') as f:
             f.write(config)
         
         # Instruct HAproxy to reload the config
-        subprocess.call(self._reload, shell=True)
+        subprocess.call('haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -sf $(cat /run/haproxy.pid)', shell=True)
         return accepted

--- a/src/backend/nginx.py
+++ b/src/backend/nginx.py
@@ -1,0 +1,30 @@
+import logging, subprocess
+from mako.template import Template
+from proxymatic.util import *
+
+class NginxBackend(object):
+    def __init__(self, domain):
+        self._domain = domain
+    
+    def update(self, source, services):
+        cfgfile = '/etc/nginx/conf.d/default.conf'
+        seen = set()
+            
+        # Nginx only supports HTTP
+        accepted = {}
+        for key, service in services.items():
+            if service.protocol == 'tcp' and service.name not in seen:
+                accepted[key] = service
+                seen.add(service.name)
+        
+        # Expand the config template
+        template = Template(filename='/etc/nginx/conf.d/default.conf.tpl')
+        config = template.render(services=accepted, domain=self._domain)
+        with open(cfgfile, 'w') as f:
+            f.write(config)
+        
+        # Instruct Nginx to reload the config
+        logging.debug("Reloaded the Nginx config '%s'", cfgfile)
+        subprocess.call('nginx -s reload', shell=True)
+        #return accepted
+        return {}

--- a/src/backend/pen.py
+++ b/src/backend/pen.py
@@ -3,11 +3,9 @@ from mako.template import Template
 from proxymatic.util import *
 
 class PenBackend(object):
-    def __init__(self, cfgtemplate, maxservers, maxclients, user):
-        self._cfgtemplate = cfgtemplate
+    def __init__(self, maxservers, maxclients):
         self._maxservers = maxservers
         self._maxclients = maxclients
-        self._user = user
         self._state = {}
         
     def update(self, source, services):
@@ -45,7 +43,7 @@ class PenBackend(object):
             'pen', 'pen',
             '-r', # Disable sticky sessions
             '-W', # Use weight/least-connected balancing mode
-            '-u', self._user,
+            '-u', 'pen',
             '-c', str(self._maxclients), 
             '-S', str(self._maxservers), 
             '-F', cfgfile, 
@@ -61,8 +59,8 @@ class PenBackend(object):
             'servers': set(service.servers)}
         
         # Write the configuration file
-        template = Template(filename=self._cfgtemplate)
-        config = template.render(service=service, maxservers=self._maxservers, mangle=mangle)
+        template = Template(filename='/etc/pen/pen.cfg.tpl')
+        config = template.render(service=service, maxservers=self._maxservers)
         with open(cfgfile, 'w') as f:
             f.write(config)
 

--- a/src/discovery/marathon.py
+++ b/src/discovery/marathon.py
@@ -83,7 +83,8 @@ class MarathonDiscovery(object):
                     
                     # Append backend to service
                     if key not in services:
-                        services[key] = Service(parts[0], 'marathon:%s' % self._url, port, protocol)
+                        name = parts[0].replace('_', '-')
+                        services[key] = Service(name, 'marathon:%s' % self._url, port, protocol)
                     services[key]._add(server)
                 except Exception, e:
                     logging.warn("Failed parse service %s backend %s: %s", parts[0], backend, str(e))


### PR DESCRIPTION
* Use nginx dynamically configured with vhosts for each
service. Enables URL's like http://my-service.app.example.com to
load balance across the replicas of that service running in e.g.
Mesos. This is same functionality like Deis router provides
* Removed some uneeded script parameters to decrease complexity.
* Switched to centos:7 as the base image